### PR TITLE
remove `max-width` css style

### DIFF
--- a/show_ip.css
+++ b/show_ip.css
@@ -1,6 +1,5 @@
 .show_left {
     max-height: 31px;
-    max-width: 180px;
     padding: 2px 10px;
     margin: 5px;
     background: rgba(0, 0, 0, 0.5);
@@ -18,7 +17,6 @@
 
 .show_right {
     max-height: 31px;
-    max-width: 180px;
     padding: 2px 10px;
     margin: 5px;
     background: rgba(0, 0, 0, 0.5);


### PR DESCRIPTION
max-width will limit the width of display area especially for those ips such as xxx.xxx.xxx.xxx(three digits per segment), or ipv6s.